### PR TITLE
Properly refer to CalendarPicker.js in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-calendar-picker",
   "version": "1.0.1",
   "description": "Calendar Picker Component for React Native",
-  "main": "CalendarPicker.js",
+  "main": "./CalendarPicker/CalendarPicker.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Otherwise, React Native packager can't find the library.